### PR TITLE
Previous and Next Chapter Buttons Implemented

### DIFF
--- a/app/(tabs)/summaries.tsx
+++ b/app/(tabs)/summaries.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import { View, Text, ActivityIndicator } from 'react-native';
 import { ReviewScreenTemplate, ReviewItem } from '@/components/ReviewScreenTemplate';
 import { useBibleBooks } from '../../context/BibleBooksContext';
@@ -8,6 +8,9 @@ export default function Summaries() {
   const { bibleBooks } = useBibleBooks();
 
   const enabledBooks = bibleBooks.filter(b => b.Enabled && b.Chapters && b.Chapters.length > 0);
+
+  const [originalBook, setOriginalBook] = useState<string | null>(null);
+  const [originalChapter, setOriginalChapter] = useState<number | null>(null);
 
   // If no enabled books with chapters, show loading or info
   if (enabledBooks.length === 0) {
@@ -34,15 +37,33 @@ export default function Summaries() {
     };
   };
 
+  // Update original chapter and book when item is fetched
+  const getRandomItem = async () => {
+    const item = await getRandomSummary();
+    setOriginalBook(item.book);
+    setOriginalChapter(item.chapter);
+    return item;
+  };
+
   const checkCorrectness = (book: string, chapter: string, item: ReviewItem) =>
     book === item.book && parseInt(chapter, 10) === item.chapter;
 
-  const renderQuestion = (item: ReviewItem, showAnswer: boolean) => {
+  const renderQuestion = (item: ReviewItem, showAnswer: boolean, originalBook: string, originalChapter: number) => {
+
+    if (!originalBook || originalChapter === null) {
+      return <Text style={{ color: 'white' }}>Loading Question...</Text>;
+    }
+
+    const isOriginalChapter = item.book === originalBook && item.chapter === originalChapter;
+
     return (
       <View>
-        <Text style={{ fontSize: 18, fontStyle: 'italic', color: showAnswer ? 'yellow' : 'white', marginBottom: 5 }}>
-          {item.text}
-        </Text>
+        {/* Only show the summary if the chapter has not navigated away from the original chapter */}
+        {isOriginalChapter && (
+          <Text style={{ fontSize: 18, fontStyle: 'italic', color: showAnswer ? 'yellow' : 'white', marginBottom: 5 }}>
+            {item.text}
+          </Text>
+        )}
         {showAnswer && (
           <>
             <Text style={{ fontWeight: 'bold', fontSize: 22, color: 'white' }}>
@@ -64,9 +85,11 @@ export default function Summaries() {
     <ReviewScreenTemplate
       title="Chapter Summary Review"
       points={5}
-      getRandomItem={getRandomSummary}
+      getRandomItem={getRandomItem}
       checkCorrectness={checkCorrectness}
-      renderQuestion={renderQuestion}
+      renderQuestion={(item, showAnswer) => 
+        renderQuestion(item, showAnswer, originalBook ?? '', originalChapter ?? 0)
+      }
     />
   );
 }


### PR DESCRIPTION
On the Summaries and Verses tabs, after showing the correct answer (by either getting a correct answer or by giving up), prev and next buttons will now display in the bottom of the verse container.

-Clicking Prev will take the user to the previous chapter in the same book (if there is one) -Clicking Next will take the user to the next chapter in the same book (if there is one) -If there is no previous or next chapter respectively, then the corresponding button will be grayed out and its underline will not appear -On the Summaries tab, only the original chapter that the user was prompted with will have its summary displayed in yellow at the top (so that the user knows when they have arrived back at the chapter they were prompted with) -Similarly, on the Verses tab, only the original chapter will have a highlighted verse (the verse the user was prompted with) -The height of the verse container has been extended since feedback is now an overlay