### PR TITLE
Score Feature Improvements

### DIFF
--- a/app/(tabs)/enabledBooks.tsx
+++ b/app/(tabs)/enabledBooks.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { FlatList, Text, View, StyleSheet, ActivityIndicator, Alert, Pressable } from 'react-native';
-import { useBibleBooks } from '../../context/BibleBooksContext';
+import { MIN_CHAPTERS_ENABLED_FOR_SCORE, useBibleBooks } from '@/context/BibleBooksContext';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { BibleBook, Chapter } from '../../types';
 import BulkRarityEditor from '../../components/ui/BulkRarityEditor'
@@ -21,9 +21,28 @@ export default function EnabledBooksScreen() {
     updateChapterRarity,
     isLoading,
     error,
+    enabledChapterCount,
+    scoreEnabledFlag,
+    setScoreEnabledFlag
   } = useBibleBooks();
   const [expandedBook, setExpandedBook] = useState<string | null>(null);
   const [longPressActive, setLongPressActive] = useState(false);
+
+  useEffect(() => {
+    if (enabledChapterCount < MIN_CHAPTERS_ENABLED_FOR_SCORE && scoreEnabledFlag) {
+      Alert.alert(
+        'Score Disabled',
+        `Score has been disabled since fewer than ${MIN_CHAPTERS_ENABLED_FOR_SCORE} chapters are enabled.`
+      );
+      setScoreEnabledFlag(false);
+    } else if (enabledChapterCount >= MIN_CHAPTERS_ENABLED_FOR_SCORE && !scoreEnabledFlag) {
+      Alert.alert(
+        'Score Enabled',
+        `Score has been enabled since at least ${MIN_CHAPTERS_ENABLED_FOR_SCORE} chapters are enabled.`
+      );
+      setScoreEnabledFlag(true);
+    }
+  }, [enabledChapterCount, scoreEnabledFlag]);
 
   const handlePress = useCallback(async (bookName: string) => {
     // Skip if this was a long press
@@ -161,11 +180,13 @@ export default function EnabledBooksScreen() {
     );
   }
 
+  const totalEnabledBooks = bibleBooks.filter(b => b.enabled).length;
+
   return (
     <View style={styles.container}>
       <View style={styles.header}>
         <Text style={styles.subHeaderText}>
-          {bibleBooks.filter(b => b.enabled).length} books enabled
+          {totalEnabledBooks} books enabled — {enabledChapterCount} chapters enabled
         </Text>
       </View>
 

--- a/app/(tabs)/verses.tsx
+++ b/app/(tabs)/verses.tsx
@@ -65,7 +65,7 @@ export default function Verses() {
   return (
     <ReviewScreenTemplate
       title="Verse Review"
-      points={5}
+      points={10}
       getRandomItem={getRandomVerse}
       checkCorrectness={checkCorrectness}
       renderQuestion={renderQuestion}

--- a/components/ui/BulkRarityEditor.tsx
+++ b/components/ui/BulkRarityEditor.tsx
@@ -62,7 +62,7 @@ export default function BulkRarityEditor({
 
         await updateBookEnabledStatus(book.bookName);
 
-        Alert.alert('Success', `Rarities ${direction}d for ${chaptersToUpdate.length} chapters.`);
+        //Alert.alert('Success', `Rarities ${direction}d for ${chaptersToUpdate.length} chapters.`);
     } catch (err: any) {
         console.error(err);
         Alert.alert('Error', 'Failed to adjust chapter rarities.');
@@ -104,7 +104,7 @@ export default function BulkRarityEditor({
 
       await updateBookEnabledStatus(book.bookName);
 
-      Alert.alert('Success', `Updated ${chaptersToUpdate.length} chapters.`);
+      //Alert.alert('Success', `Updated ${chaptersToUpdate.length} chapters.`);
     } catch (err: any) {
       console.error(err);
       Alert.alert('Error', 'Failed to update chapter rarities.');


### PR DESCRIPTION
- the Verses tab is now worth double the amount of points on the Summaries tab

- no points will be awarded to users if users have fewer than 20 chapters enabled (to prevent point-farming). To make this more apparent to the user, the number of enabled chapters now displays on the enabled books page, and an alert appears when scoring has been enabled or disabled.

- the user will obtain some points for getting a correct answer on second or third try (currently 40% of max points on second try and 20% of max points on third try)