### PR TITLE
Setting for Try Another

### DIFF
--- a/app/(tabs)/account.tsx
+++ b/app/(tabs)/account.tsx
@@ -7,11 +7,13 @@ import { useRouter } from 'expo-router';
 import { useAuth } from '../../context/AuthContext';
 import { Switch, View } from 'react-native';
 import { useThemeContext } from '@/context/ThemeContext';
+import { useSettings } from '../../context/SettingsContext';
 
 export default function Settings() {
   const router = useRouter();
   const { signOut } = useAuth();
   const { colorScheme, setColorScheme, theme } = useThemeContext();
+  const { holdToTryAnother, setHoldToTryAnotherSetting } = useSettings();
 
   const handleSwitchAccount = async (router: any) => {
     await signOut();
@@ -33,19 +35,31 @@ export default function Settings() {
         <ThemedText type="title" style={{color: theme.text}}>Account</ThemedText>
       </ThemedView>
 
-      <ThemedView style={{ marginTop: 20 }}>
+      <ThemedView style={{ marginTop: 10, borderBottomWidth: 2, borderBottomColor: theme.horizontalDivider }}>
         <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 20, backgroundColor: theme.background }}>
           <Text style={{ color: theme.text, fontSize: 16 }}>Dark Mode</Text>
           <Switch
             value={colorScheme === 'dark'}
             onValueChange={(value) => setColorScheme(value ? 'dark' : 'light')}
-            thumbColor="#228B22"
+            thumbColor="#777777"
             trackColor={{ false: '#999999', true: '#98FF98' }}
           />
         </View>
       </ThemedView>
 
-      <ThemedView style={{ marginTop: 40, backgroundColor: theme.background }}>
+      <ThemedView style={{ marginTop: 0 }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', paddingHorizontal: 20, backgroundColor: theme.background, marginTop: 0 }}>
+          <Text style={{ color: theme.text, fontSize: 16 }}>Hold to Try Another</Text>
+          <Switch
+            value={holdToTryAnother}
+            onValueChange={setHoldToTryAnotherSetting}
+            thumbColor="#777777"
+            trackColor={{ false: '#999999', true: '#98FF98' }}
+          />
+        </View>
+      </ThemedView>
+
+      <ThemedView style={{ marginTop: 20, backgroundColor: theme.background }}>
         <TouchableOpacity
           onPress={() => handleSwitchAccount(router)}
           style={{

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -14,6 +14,7 @@ import { ServicesProvider } from '../context/ServicesContext';
 import { BackendProvider } from '../context/BackendContext';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { ThemeLoader } from '../context/ThemeLoader';
+import { SettingsProvider } from '../context/SettingsContext';
 
 export default function Layout() {
   const [fontsLoaded, fontError] = useFonts({
@@ -60,8 +61,10 @@ function InnerApp() {
         <BibleBooksProvider>
           <ScoreProvider>
             <ThemeProvider>
-              <ThemeLoader userId={user.id} />
-              <LayoutContent />
+              <SettingsProvider userId={user.id}>
+                <ThemeLoader userId={user.id} />
+                <LayoutContent />
+              </SettingsProvider>
             </ThemeProvider>
           </ScoreProvider>
         </BibleBooksProvider>

--- a/components/ReviewScreenTemplate.tsx
+++ b/components/ReviewScreenTemplate.tsx
@@ -19,6 +19,8 @@ import { SimpleBottomSheet } from './SimpleBottomSheet'; // Adjust path if neede
 import ConfettiCannon from 'react-native-confetti-cannon'
 import { Chapter } from '../types';
 import { useThemeContext } from '../context/ThemeContext';
+import { useSettings } from '../context/SettingsContext';
+import { LongPressButton } from '../components/ui/LongPressButton';
 
 interface ContextVerse {
   verseNumber: number;
@@ -70,6 +72,7 @@ export const ReviewScreenTemplate: React.FC<ReviewScreenTemplateProps> = ({
   const [isSheetVisible, setIsSheetVisible] = useState(false);
   const [showConfetti, setShowConfetti] = React.useState(false);
   const shakeAnim = useRef(new Animated.Value(0)).current;
+  const { holdToTryAnother } = useSettings();
   const { theme } = useThemeContext();
 
   const {
@@ -346,9 +349,13 @@ export const ReviewScreenTemplate: React.FC<ReviewScreenTemplateProps> = ({
         )}
 
         <View style={styles.bottomButtonContainer}>
-          <TouchableOpacity style={[styles.tryAnotherButton, {backgroundColor: theme.neutralButton}]} onPress={loadNewItem}>
-            <Text style={styles.tryAnotherButtonText}>Try Another</Text>
-          </TouchableOpacity>
+          {holdToTryAnother ? (
+            <LongPressButton onLongPress={loadNewItem} label="Try Another" />
+          ) : (
+            <TouchableOpacity onPress={loadNewItem} style={[styles.tryAnotherButton, {backgroundColor: theme.neutralButton}]}>
+              <Text style={styles.tryAnotherButtonText}>Try Another</Text>
+            </TouchableOpacity>
+          ) }
         </View>
         
         {showConfetti && (

--- a/components/ui/LongPressButton.tsx
+++ b/components/ui/LongPressButton.tsx
@@ -1,0 +1,107 @@
+import React, { useRef } from 'react';
+import {
+  Pressable,
+  Text,
+  StyleSheet,
+  View,
+  Animated,
+  Easing,
+} from 'react-native';
+
+interface LongPressButtonProps {
+  onLongPress: () => void;
+  duration?: number;
+  label?: string;
+}
+
+export const LongPressButton: React.FC<LongPressButtonProps> = ({
+  onLongPress,
+  duration = 1200,
+  label = 'Try Another',
+}) => {
+  const progress = useRef(new Animated.Value(0)).current;
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const animationRef = useRef<Animated.CompositeAnimation | null>(null);
+
+  const startHold = () => {
+    progress.setValue(0);
+
+    animationRef.current = Animated.timing(progress, {
+      toValue: 1,
+      duration,
+      easing: Easing.linear,
+      useNativeDriver: false,
+    });
+
+    animationRef.current.start();
+
+    timeoutRef.current = setTimeout(() => {
+      onLongPress();
+      reset();
+    }, duration);
+  };
+
+  const cancelHold = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    animationRef.current?.stop();
+    reset();
+  };
+
+  const reset = () => {
+    progress.setValue(0);
+  };
+
+  const fillWidth = progress.interpolate({
+    inputRange: [0, 1],
+    outputRange: ['0%', '100%'],
+  });
+
+  return (
+    <Pressable
+      onPressIn={startHold}
+      onPressOut={cancelHold}
+      style={styles.wrapper}
+    >
+      <View style={styles.button}>
+        <Animated.View
+          style={[
+            styles.progressFill,
+            {
+              width: fillWidth,
+            },
+          ]}
+        />
+        <Text style={styles.label}>{label}</Text>
+      </View>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    marginTop: 10,
+  },
+  button: {
+    height: 48,
+    backgroundColor: '#007AFF',
+    borderRadius: 6,
+    overflow: 'hidden',
+    justifyContent: 'center',
+    alignItems: 'center',
+    position: 'relative',
+  },
+  progressFill: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: '#6699FF',
+    zIndex: 0,
+  },
+  label: {
+    color: '#fff',
+    fontWeight: 'bold',
+    fontSize: 16,
+    zIndex: 1,
+  },
+});

--- a/context/SettingsContext.tsx
+++ b/context/SettingsContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { getHoldToTryAnother, setHoldToTryAnother } from '../utils/UserSettings';
+
+type SettingsContextType = {
+  holdToTryAnother: boolean;
+  setHoldToTryAnotherSetting: (value: boolean) => void;
+};
+
+const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
+
+export const useSettings = () => {
+  const context = useContext(SettingsContext);
+  if (!context) throw new Error('useSettings must be used within a SettingsProvider');
+  return context;
+};
+
+export const SettingsProvider = ({ userId, children }: { userId: string; children: React.ReactNode }) => {
+  const [holdToTryAnother, setHoldToTryAnotherState] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const setting = await getHoldToTryAnother(userId);
+      setHoldToTryAnotherState(setting);
+    })();
+  }, [userId]);
+
+  const setHoldToTryAnotherSetting = async (value: boolean) => {
+    await setHoldToTryAnother(userId, value);
+    setHoldToTryAnotherState(value);
+  };
+
+  return (
+    <SettingsContext.Provider value={{ holdToTryAnother, setHoldToTryAnotherSetting }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+};

--- a/utils/UserSettings.ts
+++ b/utils/UserSettings.ts
@@ -1,0 +1,10 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const setHoldToTryAnother = async (userId: string, value: boolean) => {
+  await AsyncStorage.setItem(`holdToTryAnother-${userId}`, JSON.stringify(value));
+};
+
+export const getHoldToTryAnother = async (userId: string): Promise<boolean> => {
+  const value = await AsyncStorage.getItem(`holdToTryAnother-${userId}`);
+  return value ? JSON.parse(value) : false; // Default to false
+};


### PR DESCRIPTION
- a setting has now been added on the Account screen that allows the user to decide they should have to hold the Try Another button before receiving a new prompt. If this option is selected, the Try Another Button itself will turn into a progress bar.